### PR TITLE
Support VeSync In Wall Switches

### DIFF
--- a/HACustom_Components/switch/vesync.py
+++ b/HACustom_Components/switch/vesync.py
@@ -1,6 +1,5 @@
 """
 Support for Etekcity VeSync switches.
-
 For more details about this platform, please refer to the documentation at
 https://home-assistant.io/components/switch.vesync/
 """
@@ -23,7 +22,10 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the VeSync switch platform."""
-    from custom_components.pyvesync-v2 import VeSync
+    #from custom_components.pyvesync-v2 import VeSync
+    from . vesync import VeSync
+    from . vesync import VeSyncSwitch
+    from . vesync import VeSyncWallSwitch   
 
     switches = []
 
@@ -45,16 +47,23 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                      len(manager.devices), count_string)
 
         for switch in manager.devices:
-            switches.append(VeSyncSwitchHA(switch))
-            _LOGGER.info("Added a VeSync switch named '%s'",
-                         switch.device_name)
+            if type(switch) is VeSyncSwitch:
+                switches.append(VeSyncSwitchHA(switch))
+                _LOGGER.info("Added a VeSync switch named '%s'",
+                            switch.device_name)
+            elif type(switch) is VeSyncWallSwitch:
+                 switches.append(VeSyncWallSwitchHA(switch))
+                 _LOGGER.info("Added a VeSync wall switch named '%s'",
+                            switch.device_name)
     else:
         _LOGGER.info("No VeSync devices found")
 
     add_entities(switches)
 
 
+
 class VeSyncSwitchHA(SwitchDevice):
+    
     """Representation of a VeSync switch."""
 
     def __init__(self, plug):
@@ -106,3 +115,44 @@ class VeSyncSwitchHA(SwitchDevice):
         self.smartplug.update()
         self._current_power_w = self.smartplug.get_power()
         self._today_energy_kwh = self.smartplug.get_kwh_today()
+
+        
+class VeSyncWallSwitchHA(SwitchDevice):
+    
+    """Representation of a VeSync wall switch."""
+
+    def __init__(self, plug):
+        """Initialize the VeSync switch device."""
+        self.smartplug = plug
+
+    @property
+    def unique_id(self):
+        """Return the ID of this switch."""
+        return self.smartplug.uuid
+
+    @property
+    def name(self):
+        """Return the name of the switch."""
+        return self.smartplug.device_name
+
+    @property
+    def available(self) -> bool:
+        """Return True if switch is available."""
+        return self.smartplug.connection_status == "online"
+
+    @property
+    def is_on(self):
+        """Return True if switch is on."""
+        return self.smartplug.device_status == "on"
+
+    def turn_on(self, **kwargs):
+        """Turn the switch on."""
+        self.smartplug.turn_on()
+
+    def turn_off(self, **kwargs):
+        """Turn the switch off."""
+        self.smartplug.turn_off()
+
+    def update(self):
+        """Handle data changes for node values."""
+        self.smartplug.update()

--- a/README.md
+++ b/README.md
@@ -32,10 +32,13 @@ manager = VeSync("USERNAME", "PASSWORD")
 manager.login()
 manager.update()
 
-# Get electricity metrics of devices
+# Print Device Info
 for switch in manager.devices:
-    print("Switch %s is currently using %s watts" % (switch.device_name, switch.get_power()))
-    print("It has used %skWh of electricity today" % (switch.get_kwh_today()))
+    if type(switch) is VeSyncSwitch:
+        print("Switch %s is currently using %s watts" % (switch.device_name, switch.get_power()))
+        print("It has used %skWh of electricity today" % (switch.get_kwh_today()))
+    elif type(switch) is VeSyncWallSwitch:
+        print("Wall Switch %s found" % (switch.device_name))
 
 # Turn on the first device
 my_switch = manager.devices[0]


### PR DESCRIPTION
Joe,
Thanks for picking up development on this project again.

I've added support for the "In Wall" variant of the VeSync Wifi switches (https://www.etekcity.com/productcate/121/list)

These switches utilize a slightly different API and (from what I've seen) only support On and Off commands (no ability to read voltage or power)

I'm not really sure how to test the Home Assistant custom component.  I'm new to Home Assistant and was unsuccessful in adding the custom component to my HA instance.  If I can figure that piece out, I'm happy to update the HA component to support the In Wall switches.

